### PR TITLE
Add `created_at` to BrewerySerializer

### DIFF
--- a/app/serializers/brewery_serializer.rb
+++ b/app/serializers/brewery_serializer.rb
@@ -17,4 +17,5 @@ class BrewerySerializer < ActiveModel::Serializer
   attribute :phone
   attribute :website_url
   attribute :updated_at
+  attribute :created_at
 end


### PR DESCRIPTION
Add `created_at` to the returned data for a brewery. 